### PR TITLE
Fix reCaptcha Login and Registration Issue and Restore UserMailer Class

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,7 +20,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     respond_with_navigational(resource) do
       flash.discard(:recaptcha_error) # We need to discard flash to avoid showing it on the next page reload
-      render :new
+      return render :new
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,7 +10,7 @@ class Users::SessionsController < Devise::SessionsController
     if user && user.valid_password?(params[:user][:password])
       unless user.confirmed?
         flash[:login_alert] = "Your account is not yet activated. Please check your email for the confirmation link, or request a new one below."
-        redirect_to new_user_confirmation_path
+        redirect_to new_user_confirmation_path and return
       end
     else
       flash[:login_alert] = "Invalid email or password."
@@ -24,7 +24,7 @@ class Users::SessionsController < Devise::SessionsController
 
     respond_with_navigational(resource) do
       flash.discard(:recaptcha_error) # We need to discard flash to avoid showing it on the next page reload
-      render :new
+      return render :new
     end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,4 @@
+class UserMailer < Devise::Mailer
+  include Devise::Controllers::UrlHelpers
+  default template_path: "users/mailer"
+end


### PR DESCRIPTION
### Description
The login and registration pages required the user two attempt the reCAPTCHA twice for a successful redirect. This pull request fixes that bug using explicit `return` statements.

The pull request also restores the UserMailer class which, when removed, broke the confirmation email via Devise.