### PR TITLE
Add Day of Week to Event Form

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -18,6 +18,7 @@
 
   <div class="mb-4">
     <%= form.label :start_date, "Date", class: "block text-gray-700 font-semibold mb-1" %>
+    <span id="day_of_week" class="text-gray-600 italic"></span>
     <%= form.date_select :start_date, order: [:month, :day, :year], start_year: Date.today.year, end_year: Date.today.year + 10, required: true, class: "w-full p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
   </div>
 
@@ -59,16 +60,41 @@
       }
 
       toggleTimeFields();
-
       allDayCheckbox.addEventListener("change", toggleTimeFields);
     }
   }
 
-  document.addEventListener("turbo:load", () => {
-    handleAllDayToggle();
-  });
+  function handleDateChange() {
+    const yearSelect   = document.getElementById("event_start_date_1i");
+    const monthSelect  = document.getElementById("event_start_date_2i");
+    const daySelect    = document.getElementById("event_start_date_3i");
+    const dayOfWeekSpan = document.getElementById("day_of_week");
+
+    function updateDayOfWeek() {
+      const year  = parseInt(yearSelect.value);
+      const month = parseInt(monthSelect.value);
+      const day   = parseInt(daySelect.value);
+
+      if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
+        const date = new Date(year, month - 1, day);
+        const weekday = date.toLocaleDateString(undefined, { weekday: 'long' });
+        dayOfWeekSpan.textContent = weekday + ",";
+      } else {
+        dayOfWeekSpan.textContent = "";
+      }
+    }
+
+    updateDayOfWeek();
+
+    [yearSelect, monthSelect, daySelect].forEach(select => {
+      select.addEventListener("change", updateDayOfWeek);
+    });
+  }
 
   document.addEventListener("turbo:load", () => {
+    handleAllDayToggle();
+    handleDateChange();
+
     const dateSelects = document.querySelectorAll("select[id^='event_start_date']");
     const timeSelects = document.querySelectorAll("select[id^='event_start_time'], select[id^='event_end_time']");
     const allSelects = [...dateSelects, ...timeSelects];


### PR DESCRIPTION
## Description
This pull request adds a dynamic display of the day of the week next to the date selector in the event form. This provides users with immediate feedback on the weekday for their selected date, reducing the need to consult an external calendar.

## Screenshot
<img width="1724" alt="Event Form" src="https://github.com/user-attachments/assets/b661aba0-37c5-45ea-b695-86031c31511c" />
