### PR TITLE
Add Mailtrap API Key to Action Mailer Config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.mailtrap_settings = {
+    api_key: Rails.application.credentials.dig(:mailtrap, :api_key)
+  }
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,6 +75,9 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "pleasant_events_production"
 
   config.action_mailer.delivery_method = :mailtrap
+  config.action_mailer.mailtrap_settings = {
+    api_key: Rails.application.credentials.dig(:mailtrap, :api_key)
+  }
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.


### PR DESCRIPTION
## Description
This pull request resolves a missing API key error when creating a new user by adding `Rails.application.credentials.dig(:mailtrap, :api_key)` to the Action Mailer configuration.