### PR TITLE
Add Dependent Destroy to Clean Up Users on Account Delete

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :confirmable
 
-  has_many :events
+  has_many :events, dependent: :destroy
 
   def has_upcoming_events?
     events.where("start_date >= ?", Date.today.beginning_of_day).exists?


### PR DESCRIPTION
## Description
This pull request adds `dependent: :destroy` to the `User` model to destroy `events` when a user is deleted.