### PR TITLE
Set Ruby Version as 3.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+ruby "3.3.4"
+
 source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,5 +406,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.3.4p94
+
 BUNDLED WITH
    2.5.17


### PR DESCRIPTION
## Description
This pull request sets the Ruby version to `3.3.4` in the `Gemfile` to resolve the error below:

`zeitwerk-2.7.3 requires ruby version >= 3.2, which is incompatible with the current version, 3.1.6`