### PR TITLE
Fix reCAPTCHA Errors on First Login and Signup Attempts

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,7 +2,9 @@ class Users::PasswordsController < Devise::PasswordsController
   # POST /resource/password
   def create
     super
-    flash[:login_alert] = "If your email exists in our system, you’ll get reset instructions shortly."
+    flash[:login_alert] =
+      "If your email exists in our system, you will receive reset instructions shortly. " \
+      "Please check your inbox (and spam folder, just in case)."
   end
 
   protected

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,7 +22,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
         flash.discard(:recaptcha_error)
         render :new
       end
-      return
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,9 +2,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :check_captcha, only: [ :create ]
 
   def after_inactive_sign_up_path_for(resource)
-    flash[:login_alert] = "Thank you for signing up! " +
-      "We've sent a confirmation email to your email address. " +
-      "Please check your inbox (and spam folder, just in case) " +
+    flash[:login_alert] = "Thank you for signing up! " \
+      "We've sent a confirmation email to your email address. " \
+      "Please check your inbox (and spam folder, just in case) " \
       "to confirm your email address and activate your account."
     new_user_session_path
   end
@@ -12,15 +12,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
   private
 
   def check_captcha
-    return if verify_recaptcha
+    # initialize resource before calling verify_recaptcha so error messages attach
+    self.resource = resource_class.new(sign_up_params)
 
-    self.resource = resource_class.new sign_up_params
-    resource.validate # Look for any other validation errors besides reCAPTCHA
-    set_minimum_password_length
-
-    respond_with_navigational(resource) do
-      flash.discard(:recaptcha_error) # We need to discard flash to avoid showing it on the next page reload
-      return render :new
+    unless verify_recaptcha(model: resource)
+      resource.validate # ensure other Devise validations still show
+      set_minimum_password_length
+      respond_with_navigational(resource) do
+        flash.discard(:recaptcha_error)
+        render :new
+      end
+      return
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,7 +26,6 @@ class Users::SessionsController < Devise::SessionsController
         flash.discard(:recaptcha_error)
         render :new
       end
-      return
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,13 +18,15 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def check_captcha
-    return if verify_recaptcha
+    # make sure the resource is initialized first so recaptcha can use it
+    self.resource = resource_class.new(sign_in_params)
 
-    self.resource = resource_class.new sign_in_params
-
-    respond_with_navigational(resource) do
-      flash.discard(:recaptcha_error) # We need to discard flash to avoid showing it on the next page reload
-      return render :new
+    unless verify_recaptcha(model: resource)
+      respond_with_navigational(resource) do
+        flash.discard(:recaptcha_error)
+        render :new
+      end
+      return
     end
   end
 end


### PR DESCRIPTION
## Description

This pull request refines user-facing messages and improves reCAPTCHA handling across multiple authentication controllers. The changes focus on clarifying alert messages for a better user experience and ensuring resources are properly initialized for consistent reCAPTCHA validation.

### User-Facing Message Improvements

- Updated the password reset alert to clearly instruct users to check their inbox and spam folder.
- Enhanced the sign-up confirmation alert for improved readability and consistency.

### reCAPTCHA Enhancements

- Refactored the `check_captcha` methods in both the registration and session flows to initialize the resource before verifying reCAPTCHA, ensuring error messages attach correctly and preventing first-attempt failures.
- Simplified related code for improved maintainability and clarity.

## Reference

Resolves [Issue 56: Login Requires Submitting reCAPTCHA Twice](https://github.com/jaredblumer/happeni/issues/56).
