### PR TITLE
Add Debug Loggers to Review reCAPTCHA Issues

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,14 +18,18 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def check_captcha
-    # make sure the resource is initialized first so recaptcha can use it
-    self.resource = resource_class.new(sign_in_params)
+  self.resource = resource_class.new(sign_in_params)
 
-    unless verify_recaptcha(model: resource)
-      respond_with_navigational(resource) do
-        flash.discard(:recaptcha_error)
-        render :new
-      end
+  Rails.logger.info("DEBUG: g-recaptcha-response param: #{params['g-recaptcha-response']}")
+  
+  result = verify_recaptcha(model: resource)
+  Rails.logger.info("DEBUG: verify_recaptcha result: #{result.inspect}")
+
+  unless result
+    respond_with_navigational(resource) do
+      flash.discard(:recaptcha_error)
+      render :new
     end
   end
+end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ class Users::SessionsController < Devise::SessionsController
   self.resource = resource_class.new(sign_in_params)
 
   Rails.logger.info("DEBUG: g-recaptcha-response param: #{params['g-recaptcha-response']}")
-  
+
   result = verify_recaptcha(model: resource)
   Rails.logger.info("DEBUG: verify_recaptcha result: #{result.inspect}")
 


### PR DESCRIPTION
This pull request introduces logging for debugging reCAPTCHA verification in the `check_captcha` method of the `Users::SessionsController` class. The added logs capture the `g-recaptcha-response` parameter and the result of the `verify_recaptcha` call.

## Reference
[Issue 56: Login Requires Submitting reCAPTCHA Twice](https://github.com/jaredblumer/happeni/issues/56)