### PR TITLE
Disable Login and Submit Buttons When reCAPTCHA Fails

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -33,14 +33,30 @@
           <div class="text-sm text-indigo-500 mb-2">
             <%= flash[:recaptcha_error] %>
           </div>
-          <%= recaptcha_tags %>
+          <%= recaptcha_tags callback: "onRecaptchaSuccess" %>
         </div>
 
-        <%= f.submit "Sign Up", class: "text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-md" %>
+        <%= f.submit "Sign Up", id: "signup-submit-button", class: "text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-md" %>
         <p class="text-sm text-gray-500 mt-3">
           Already have an account? <%= link_to "Log in here.", new_session_path(resource_name), class: "text-indigo-500 hover:underline" %>
         </p>
       <% end %>
     </div>
   </div>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      var btn = document.getElementById("signup-submit-button");
+      if (btn) {
+        btn.disabled = true;
+      }
+    });
+
+    window.onRecaptchaSuccess = function () {
+      var signupBtn = document.getElementById("signup-submit-button");
+
+      if (signupBtn) {
+        signupBtn.disabled = false;
+      }
+    };
+  </script>
 </section>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -43,10 +43,10 @@
           <div class="text-sm text-indigo-500 mb-2">
             <%= flash[:recaptcha_error] %>
           </div>
-          <%= recaptcha_tags %>
+          <%= recaptcha_tags callback: "onRecaptchaSuccess" %>
         </div>
 
-        <%= f.submit "Log In", class: "text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-md" %>
+        <%= f.submit "Log In", id: "login-submit-button", class: "text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-md" %>
         <p class="text-sm text-gray-500 mt-3">
           Don't have an account? <%= link_to "Sign up here.", new_registration_path(resource_name), class: "text-indigo-500 hover:underline" %><br />
           Forgot your password? <%= link_to "Reset your password.", new_password_path(resource_name), class: "text-indigo-500 hover:underline" %>
@@ -54,5 +54,20 @@
       <% end %>
     </div>
   </div>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      var btn = document.getElementById("login-submit-button");
+      if (btn) {
+        btn.disabled = true;
+      }
+    });
+
+    window.onRecaptchaSuccess = function () {
+      var btn = document.getElementById("login-submit-button");
+      if (btn) {
+        btn.disabled = false;
+      }
+    }
+  </script>
 </section>
 


### PR DESCRIPTION
## Description
This pull request enhances the user experience for forms in the registration and login pages by integrating a reCAPTCHA callback mechanism and improving button behavior. The changes ensure that the submit buttons are disabled until the reCAPTCHA validation is successfully completed.

## Reference
[Issue 56: Login Requires Submitting reCAPTCHA Twice](https://github.com/jaredblumer/happeni/issues/56)