### PR TITLE
Change subscribed_to_email Default to true for New Users

### DIFF
--- a/db/migrate/20250704192300_change_subscribed_to_email_default_on_users.rb
+++ b/db/migrate/20250704192300_change_subscribed_to_email_default_on_users.rb
@@ -1,0 +1,5 @@
+class ChangeSubscribedToEmailDefaultOnUsers < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :users, :subscribed_to_email, from: false, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_03_011859) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_04_192300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_03_011859) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "subscribed_to_email", default: false, null: false
+    t.boolean "subscribed_to_email", default: true, null: false
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
## Description
This pull request updates the default value of the `subscribed_to_email` column in the `users` table to ensure new users are subscribed to email notifications by default. The changes include a migration file and corresponding updates to the schema.