### PR TITLE
Disable Turbo on Log Out

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -31,7 +31,7 @@
         <%= link_to "Event Ideas", event_ideas_path, class: "block text-center py-2 lg:mr-5 text-gray-700 hover:text-gray-900" %>
         <%= link_to "Settings", settings_path, class: "block text-center py-2 lg:mr-5 text-gray-700 hover:text-gray-900" %>
         <div class="block text-center py-2 lg:mr-5">
-          <%= button_to "Log Out", destroy_user_session_path, method: :delete, class: "w-full text-gray-700 hover:text-gray-900" %>
+          <%= button_to "Log Out", destroy_user_session_path, data: { turbo: false }, method: :delete, class: "w-full text-gray-700 hover:text-gray-900" %>
         </div>
       <% else %>
         <%= link_to "Sign Up", new_user_registration_path, data: { turbo: false }, class: "block text-center py-2 lg:mr-5 text-gray-700 hover:text-gray-900" %>


### PR DESCRIPTION
## Description
This pull request includes a small but important change to the `app/views/shared/_navigation.html.erb` file. The change ensures that the "Log Out" button no longer uses Turbo by adding a `data: { turbo: false }` attribute. This change is intended to resolve issues on logging back in on first try after logging out.

## Reference
[Issue 56: Login Requires Submitting reCAPTCHA Twice](https://github.com/jaredblumer/happeni/issues/56)