### PR TITLE
Resolve End Time Save Issue

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -78,6 +78,7 @@ class EventsController < ApplicationController
       :all_day,
       :start_date,
       :start_time,
+      :end_date,
       :end_time
     )
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -66,8 +66,14 @@ class Event < ApplicationRecord
       self.start_at = Time.zone.parse("#{@start_date} #{@start_time}")
     end
 
-    if @end_date.present? && @end_time.present?
-      self.end_at = Time.zone.parse("#{@end_date} #{@end_time}")
+    if @end_time.present?
+      end_date_to_use = @end_date.presence || @start_date
+      end_at_candidate = Time.zone.parse("#{end_date_to_use} #{@end_time}")
+      # If end time is before start time and no end_date is given, assume next day
+      if @end_date.blank? && self.start_at.present? && end_at_candidate <= self.start_at
+        end_at_candidate += 1.day
+      end
+      self.end_at = end_at_candidate
     end
   end
 

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -21,7 +21,7 @@
               <span class="mt-1 text-gray-500 text-sm"><%= event.start_at.strftime("%b %d, %Y") %></span>
               <% unless event.all_day %>
                 <span class="mt-1 text-gray-500 text-xs">
-                  <%= event.start_at.strftime("%I:%M %p") %> - <%= event.end_at.strftime("%I:%M %p") %>
+                  <%= event.start_at&.strftime("%I:%M %p") %> - <%= event.end_at&.strftime("%I:%M %p") %>
                 </span>
               <% end %>
             </div>


### PR DESCRIPTION
This pull request introduces enhancements to the event scheduling system by adding support for inferred end dates and improving date-time handling. The key changes include modifying the event parameters to include `end_date`, updating the logic for combining date and time fields to handle cases where `end_date` is missing, and ensuring safer rendering of time ranges in the event view.

### Enhancements to event scheduling logic:

* **Added `end_date` to permitted parameters**: Updated the `event_params` method in `EventsController` to include `end_date`, allowing it to be passed through the form submission.
* **Improved `combine_datetime_fields` logic**: Modified the `combine_datetime_fields` method in the `Event` model to infer `end_date` from `start_date` if it is not provided. Additionally, added logic to handle cases where the `end_time` is earlier than the `start_time` by assuming the event ends the next day.

### Improvements to event display:

* **Safe rendering of time ranges**: Updated the `_events.html.erb` view to use safe navigation (`&.`) when rendering `start_at` and `end_at` times, preventing potential errors if these attributes are `nil`.